### PR TITLE
Add support for HTTP/HTTPS proxies

### DIFF
--- a/plz-media-type.el
+++ b/plz-media-type.el
@@ -1,10 +1,13 @@
-;;; plz-media-type.el --- plz content types -*- lexical-binding: t; -*-
+;;; plz-media-type.el --- Plz Media Types -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019-2023  Free Software Foundation, Inc.
 
 ;; Author: r0man <roman@burningswell.com>
 ;; Maintainer: r0man <roman@burningswell.com>
 ;; URL: https://github.com/r0man/plz-media-type.el
+;; Version: 0.1-pre
+;; Package-Requires: ((emacs "26.3") (plz "0.8"))
+;; Keywords: comm, network, http
 
 ;; This file is part of GNU Emacs.
 
@@ -170,6 +173,21 @@ response will not be decoded.")
                                     (list handler msg))
                 (timer-activate timer))))
 
+(defun plz-media-type--skip-proxy-headers ()
+  "Skip proxy headers in current buffer."
+  (when (looking-at plz-http-response-status-line-regexp)
+    (let* ((status-code (string-to-number (match-string 2)))
+           (reason-phrase (match-string 3)))
+      (when (and (equal 200 status-code)
+                 (equal "Connection established" reason-phrase))
+        (re-search-forward "\r\n\r\n" nil t)))))
+
+(defun plz-media-type--skip-redirect-headers ()
+  "Skip HTTP redirect headers in current buffer."
+  (when (and (looking-at plz-http-response-status-line-regexp)
+             (member (string-to-number (match-string 2)) '(301 302 303 307 308)))
+    (re-search-forward "\r\n\r\n" nil t)))
+
 (defun plz-media-type--parse-headers ()
   "Parse the HTTP response headers in the current buffer."
   (forward-line 1)
@@ -184,15 +202,20 @@ response will not be decoded.")
 (cl-defun plz-media-type--parse-response ()
   "Parse the response in the current buffer."
   (when (re-search-forward plz-http-end-of-headers-regexp nil t)
-    (let ((end-of-headers (point)))
-      (goto-char (point-min))
-      (when (looking-at plz-http-response-status-line-regexp)
-        (prog1 (make-plz-response
-                :version (string-to-number (match-string 1))
-                :status (string-to-number (match-string 2))
-                :headers (plz-media-type--parse-headers)
-                :body (buffer-substring end-of-headers (point-max)))
-          (goto-char end-of-headers))))))
+    (goto-char (point-min))
+    (plz-media-type--skip-proxy-headers)
+    (while (plz-media-type--skip-redirect-headers))
+    (let ((start-of-response (point)))
+      (when (re-search-forward plz-http-end-of-headers-regexp nil t)
+        (let ((end-of-headers (point)))
+          (goto-char start-of-response)
+          (when (looking-at plz-http-response-status-line-regexp)
+            (prog1 (make-plz-response
+                    :version (string-to-number (match-string 1))
+                    :status (string-to-number (match-string 2))
+                    :headers (plz-media-type--parse-headers)
+                    :body (buffer-substring end-of-headers (point-max)))
+              (goto-char end-of-headers))))))))
 
 (defun plz-media-type-process-filter (process media-types string)
   "The process filter that handles different content types.
@@ -534,13 +557,12 @@ parsing the HTTP response body with the
 (cl-defun plz-media-type-request
     (method
      url
-     &rest rest &key headers body else finally noquery
+     &rest rest &key headers body else finally noquery timeout
      (as 'string)
      (body-type 'text)
      (connect-timeout plz-connect-timeout)
      (decode t decode-s)
-     (then 'sync)
-     (timeout plz-timeout))
+     (then 'sync))
   "Request METHOD from URL with curl.
 
 This function works in a similar way as the `plz' function, with
@@ -640,8 +662,8 @@ THEN or ELSE, as appropriate.  For synchronous requests, this
 argument is ignored.
 
 CONNECT-TIMEOUT and TIMEOUT are a number of seconds that limit
-how long it takes to connect to a host and to receive a response
-from a host, respectively.
+how long it takes to connect to a host and to receive a complete
+response from a host, respectively.
 
 NOQUERY is passed to `make-process', which see.
 


### PR DESCRIPTION
This adds support for HTTP/HTTPS proxies. The code that was dealing
with this in plz.el wasn't migrated and we did not had any tests for
this. This should now be fixed. See:

- https://github.com/r0man/plz-media-type/pull/8
- https://github.com/r0man/plz-event-source/pull/5

It fixes the issue #48 reported by @theasp. He tested the code with
Ollama behind a Squid proxy. I tested it with Vertex and OpenAI behind
a tinyproxy.

https://github.com/ahyatt/llm/issues/48